### PR TITLE
Fix endValues=0 was changed to 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 function ease(options) {
   var startValue = options.startValue || 0;
-  var endValue = options.endValue || 1;
+  var endValue = options.endValue || 0;
   var durationMs = options.durationMs || 200;
   var onComplete = options.onComplete || function() {};
 


### PR DESCRIPTION
In your example:
ease({
  startValue: window.scrollY,
  endValue: 0,
  onStep: value => window.scroll(0, value),
});

The value of endValue property is changed to 1 after init. So that if you want to scroll to theTOP  you finish on 1 instead of 0.